### PR TITLE
Syswhispers good

### DIFF
--- a/Syscall_Injection/main.c
+++ b/Syscall_Injection/main.c
@@ -223,6 +223,7 @@ void detectDebug() {
         sizeof(DWORD64),
         NULL
     );
+
     if (isDebuggerPreset != NULL) {
         // detected a debugger
         printf("PROCESS IS BEING WATCHED!!!!!!!!!!!!!!!!!");


### PR DESCRIPTION
checks to quit if debugger is present or if process debugger object present - anti analysis/forensic checks